### PR TITLE
[3.2] appbase submodule: Fix build when build path has spaces

### DIFF
--- a/version.cmake.in
+++ b/version.cmake.in
@@ -5,7 +5,7 @@ execute_process(
    OUTPUT_VARIABLE VERSION_STRING
    OUTPUT_STRIP_TRAILING_WHITESPACE
    RESULT_VARIABLE res
-   WORKING_DIRECTORY @CMAKE_SOURCE_DIR@
+   WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@"
 )
 if(NOT ${res} STREQUAL "0")
   message(FATAL_ERROR "git describe failed")
@@ -15,4 +15,4 @@ if("${VERSION_STRING}" STREQUAL "")
   set(VERSION_STRING "unknown")
 endif()
 
-configure_file(@CMAKE_CURRENT_SOURCE_DIR@/version.cpp.in @CMAKE_CURRENT_BINARY_DIR@/version.cpp @ONLY ESCAPE_QUOTES)
+configure_file("@CMAKE_CURRENT_SOURCE_DIR@/version.cpp.in" "@CMAKE_CURRENT_BINARY_DIR@/version.cpp" @ONLY ESCAPE_QUOTES)


### PR DESCRIPTION
Backport appbase submodule portion of https://github.com/eosnetworkfoundation/mandel/issues/424. Resolve https://github.com/eosnetworkfoundation/mandel-appbase/issues/7.

The original PR was done in the short period when appbase was not a submodule.