### PR TITLE
change how version.cpp is handled by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ endif()
 
 add_library( appbase
              application.cpp
-             version.cpp
              ${HEADERS}
            )
 
@@ -65,6 +64,7 @@ else()
   set(VERSION_STRING "Unknown")
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.cpp @ONLY ESCAPE_QUOTES)
 endif()
+target_sources(appbase PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
 set(CPACK_PACKAGING_INSTALL_PREFIX /)
 


### PR DESCRIPTION
This is a bugfix to the previous PR which will allow for compilation.